### PR TITLE
Update dependency @types/escape-string-regexp to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
             }
         },
         "@types/escape-string-regexp": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/escape-string-regexp/-/escape-string-regexp-0.0.30.tgz",
-            "integrity": "sha1-jPrwtdLkaUPW79d9P00Yv6HJ8iU=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/escape-string-regexp/-/escape-string-regexp-1.0.0.tgz",
+            "integrity": "sha512-KAruqgk9/340M4MYYasdBET+lyYN8KMXUuRKWO72f4SbmIMMFp9nnJiXUkJS0HC2SFe4x0R/fLozXIzqoUfSjA==",
             "dev": true
         },
         "@types/mocha": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "regexp": "^1.0.0"
     },
     "devDependencies": {
-        "@types/escape-string-regexp": "0.0.30",
+        "@types/escape-string-regexp": "1.0.0",
         "@types/mocha": "2.2.40",
         "@types/node": "7.0.12",
         "@types/ramda": "0.0.7",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>@types/escape-string-regexp</code> (<a href="https://renovatebot.com/gh/DefinitelyTyped/DefinitelyTyped">source</a>) from <code>v0.0.30</code> to <code>v1.0.0</code></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>