### PR TITLE
Update dependency eslint to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,63 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "@renovate/pep440": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/@renovate/pep440/-/pep440-0.4.0.tgz",
@@ -59,36 +116,44 @@
             "dev": true
         },
         "acorn-jsx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+            "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
             "dev": true,
             "requires": {
-                "acorn": "^3.0.4"
+                "acorn": "^5.0.3"
+            }
+        },
+        "ajv": {
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+            "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "3.3.0",
-                    "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 }
             }
         },
-        "ajv": {
-            "version": "4.11.8",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-            "dev": true,
-            "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
-            }
-        },
         "ajv-keywords": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-            "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+            "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
             "dev": true
         },
         "ansi-cyan": {
@@ -101,9 +166,9 @@
             }
         },
         "ansi-escapes": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
             "dev": true
         },
         "ansi-gray": {
@@ -282,17 +347,6 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
-        },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            }
         },
         "backoff": {
             "version": "2.5.0",
@@ -674,6 +728,12 @@
             "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
             "dev": true
         },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
         "child-process-promise": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
@@ -704,12 +764,12 @@
             "dev": true
         },
         "cli-cursor": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-            "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^1.0.1"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -962,15 +1022,6 @@
             "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
             "dev": true
         },
-        "d": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-            "dev": true,
-            "requires": {
-                "es5-ext": "^0.10.9"
-            }
-        },
         "dargs": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -1004,12 +1055,12 @@
             "dev": true
         },
         "debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+            "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
             "dev": true,
             "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.1"
             }
         },
         "decamelize": {
@@ -1301,145 +1352,152 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "es5-ext": {
-            "version": "0.10.46",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-            "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
-            "dev": true,
-            "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "1"
-            }
-        },
-        "es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
-            }
-        },
-        "es6-map": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14",
-                "es6-iterator": "~2.0.1",
-                "es6-set": "~0.1.5",
-                "es6-symbol": "~3.1.1",
-                "event-emitter": "~0.3.5"
-            }
-        },
-        "es6-set": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14",
-                "es6-iterator": "~2.0.1",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "~0.3.5"
-            }
-        },
-        "es6-symbol": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
-            }
-        },
-        "es6-weak-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.14",
-                "es6-iterator": "^2.0.1",
-                "es6-symbol": "^3.1.1"
-            }
-        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
-        "escope": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+        "eslint": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
+            "integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
             "dev": true,
             "requires": {
-                "es6-map": "^0.1.3",
-                "es6-weak-map": "^2.0.1",
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.5.3",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.1.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.12.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.1",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+            "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+            "dev": true,
+            "requires": {
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
             }
         },
-        "eslint": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-            "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "^6.16.0",
-                "chalk": "^1.1.3",
-                "concat-stream": "^1.5.2",
-                "debug": "^2.1.1",
-                "doctrine": "^2.0.0",
-                "escope": "^3.6.0",
-                "espree": "^3.4.0",
-                "esquery": "^1.0.0",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^2.0.0",
-                "glob": "^7.0.3",
-                "globals": "^9.14.0",
-                "ignore": "^3.2.0",
-                "imurmurhash": "^0.1.4",
-                "inquirer": "^0.12.0",
-                "is-my-json-valid": "^2.10.0",
-                "is-resolvable": "^1.0.0",
-                "js-yaml": "^3.5.1",
-                "json-stable-stringify": "^1.0.0",
-                "levn": "^0.3.0",
-                "lodash": "^4.0.0",
-                "mkdirp": "^0.5.0",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.1",
-                "pluralize": "^1.2.1",
-                "progress": "^1.1.8",
-                "require-uncached": "^1.0.2",
-                "shelljs": "^0.7.5",
-                "strip-bom": "^3.0.0",
-                "strip-json-comments": "~2.0.1",
-                "table": "^3.7.8",
-                "text-table": "~0.2.0",
-                "user-home": "^2.0.0"
-            }
+        "eslint-utils": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+            "dev": true
+        },
+        "eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+            "dev": true
         },
         "espree": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
+            "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
             "dev": true,
             "requires": {
-                "acorn": "^5.5.0",
-                "acorn-jsx": "^3.0.0"
+                "acorn": "^5.6.0",
+                "acorn-jsx": "^4.1.1"
             }
         },
         "esprima": {
@@ -1477,16 +1535,6 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
-        },
-        "event-emitter": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
-            }
         },
         "event-stream": {
             "version": "3.3.6",
@@ -1541,12 +1589,6 @@
                 }
             }
         },
-        "exit-hook": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-            "dev": true
-        },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -1587,6 +1629,28 @@
             "dev": true,
             "requires": {
                 "kind-of": "^1.1.0"
+            }
+        },
+        "external-editor": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "dependencies": {
+                "tmp": {
+                    "version": "0.0.33",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+                    "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+                    "dev": true,
+                    "requires": {
+                        "os-tmpdir": "~1.0.2"
+                    }
+                }
             }
         },
         "extglob": {
@@ -1678,13 +1742,12 @@
             "dev": true
         },
         "figures": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -1854,6 +1917,12 @@
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
             }
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
         },
         "generate-function": {
             "version": "2.3.1",
@@ -2160,9 +2229,9 @@
             }
         },
         "globals": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "version": "11.7.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+            "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
             "dev": true
         },
         "globby": {
@@ -2731,9 +2800,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "3.3.10",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true
         },
         "imurmurhash": {
@@ -2774,31 +2843,99 @@
             "dev": true
         },
         "inquirer": {
-            "version": "0.12.0",
-            "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-            "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+            "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^1.1.0",
-                "ansi-regex": "^2.0.0",
-                "chalk": "^1.0.0",
-                "cli-cursor": "^1.0.1",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
                 "cli-width": "^2.0.0",
-                "figures": "^1.3.5",
-                "lodash": "^4.3.0",
-                "readline2": "^1.0.1",
-                "run-async": "^0.1.0",
-                "rx-lite": "^3.1.2",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.0",
+                "external-editor": "^3.0.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.10",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.1.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
                 "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
-        },
-        "interpret": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-            "dev": true
         },
         "into-stream": {
             "version": "3.1.0",
@@ -3024,6 +3161,12 @@
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
             "dev": true
         },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
         "is-property": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -3122,9 +3265,9 @@
             }
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
@@ -3185,6 +3328,12 @@
             "requires": {
                 "jsonify": "~0.0.0"
             }
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
         },
         "json-stringify-pretty-compact": {
             "version": "1.2.0",
@@ -4138,9 +4287,9 @@
             }
         },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
             "dev": true
         },
         "multimatch": {
@@ -4228,10 +4377,10 @@
             "dev": true,
             "optional": true
         },
-        "next-tick": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
         "nimn-date-parser": {
@@ -7452,10 +7601,13 @@
             }
         },
         "onetime": {
-            "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-            "dev": true
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
         },
         "openpgp": {
             "version": "2.6.2",
@@ -7731,12 +7883,6 @@
             "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
             "dev": true
         },
-        "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
-        },
         "path-type": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -7804,9 +7950,9 @@
             }
         },
         "pluralize": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-            "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
             "dev": true
         },
         "pnpm": {
@@ -7846,9 +7992,9 @@
             "dev": true
         },
         "progress": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
             "dev": true
         },
         "promise-inflight": {
@@ -8063,26 +8209,6 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "readline2": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-            "dev": true,
-            "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "mute-stream": "0.0.5"
-            }
-        },
-        "rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
-            "requires": {
-                "resolve": "^1.1.6"
-            }
-        },
         "redent": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -8106,6 +8232,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/regexp/-/regexp-1.0.0.tgz",
             "integrity": "sha1-UzR6Yd7ARRRjIpzCHFZgx1au1wA="
+        },
+        "regexpp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
+            "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
+            "dev": true
         },
         "registry-auth-token": {
             "version": "3.3.2",
@@ -8488,15 +8620,6 @@
                 "resolve-from": "^1.0.0"
             }
         },
-        "resolve": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-            "dev": true,
-            "requires": {
-                "path-parse": "^1.0.5"
-            }
-        },
         "resolve-dir": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
@@ -8581,13 +8704,13 @@
             }
         },
         "restore-cursor": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-            "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "exit-hook": "^1.0.0",
-                "onetime": "^1.0.0"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -8615,12 +8738,12 @@
             }
         },
         "run-async": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-            "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0"
+                "is-promise": "^2.1.0"
             }
         },
         "run-queue": {
@@ -8632,11 +8755,14 @@
                 "aproba": "^1.1.1"
             }
         },
-        "rx-lite": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-            "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-            "dev": true
+        "rxjs": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+            "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
         },
         "safe-buffer": {
             "version": "5.1.2",
@@ -8708,17 +8834,6 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
-        "shelljs": {
-            "version": "0.7.8",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-            "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-            "dev": true,
-            "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            }
-        },
         "showdown": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
@@ -8761,10 +8876,21 @@
             }
         },
         "slice-ansi": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-            "dev": true
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                }
+            }
         },
         "slide": {
             "version": "1.1.6",
@@ -9080,23 +9206,49 @@
             "dev": true
         },
         "table": {
-            "version": "3.8.3",
-            "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
-            "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+            "version": "4.0.3",
+            "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+            "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
             "dev": true,
             "requires": {
-                "ajv": "^4.7.0",
-                "ajv-keywords": "^1.0.0",
-                "chalk": "^1.1.1",
-                "lodash": "^4.0.0",
-                "slice-ansi": "0.0.4",
-                "string-width": "^2.0.0"
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
+                "slice-ansi": "1.0.0",
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
@@ -9122,6 +9274,15 @@
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -9288,6 +9449,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
             "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+            "dev": true
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
             "dev": true
         },
         "tunnel": {
@@ -9498,6 +9665,23 @@
             "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
             "dev": true
         },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                }
+            }
+        },
         "url-join": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
@@ -9518,15 +9702,6 @@
             "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
             "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
             "dev": true
-        },
-        "user-home": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-            "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-            "dev": true,
-            "requires": {
-                "os-homedir": "^1.0.0"
-            }
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@types/mocha": "2.2.40",
         "@types/node": "7.0.12",
         "@types/ramda": "0.0.7",
-        "eslint": "3.19.0",
+        "eslint": "5.6.0",
         "mocha": "3.2.0",
         "renovate": "13.67.1",
         "typescript": "2.2.2",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>eslint</code> (<a href="https://eslint.org">homepage</a>, <a href="https://renovatebot.com/gh/eslint/eslint">source</a>) from <code>v3.19.0</code> to <code>v5.6.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v560httpsgithubcomeslinteslintreleasesv560"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.6.0"><code>v5.6.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.5.0…v5.6.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/c5b688e"><code>c5b688e</code></a> Update: Added generators option to func-names (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9511">#&#8203;9511</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10697">#&#8203;10697</a>) (Oscar Barrett)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7da36d5"><code>7da36d5</code></a> Fix: respect generator function expressions in no-constant-condition (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10827">#&#8203;10827</a>) (Julian Rosse)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0a65844"><code>0a65844</code></a> Chore: quote enable avoidEscape option in eslint-config-eslint (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10626">#&#8203;10626</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/32f41bd"><code>32f41bd</code></a> Chore: Add configuration wrapper markdown for the bug report template (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10669">#&#8203;10669</a>) (Iulian Onofrei)</li>
</ul>
<hr />
<h3 id="v550httpsgithubcomeslinteslintreleasesv550"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.5.0"><code>v5.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.4.0…v5.5.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6e110e6"><code>6e110e6</code></a> Fix: camelcase duplicate warning bug (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10801">#&#8203;10801</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10802">#&#8203;10802</a>) (Julian Rosse)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5103ee7"><code>5103ee7</code></a> Docs: Add Brackets integration (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10813">#&#8203;10813</a>) (Jan Pilzer)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b61d2cd"><code>b61d2cd</code></a> Update: max-params to only highlight function header (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10815">#&#8203;10815</a>) (Ian Obermiller)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2b2f11d"><code>2b2f11d</code></a> Upgrade: babel-code-frame to version 7 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10808">#&#8203;10808</a>) (Rouven Weßling)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2824d43"><code>2824d43</code></a> Docs: fix comment placement in a code example (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10799">#&#8203;10799</a>) (Vse Mozhet Byt)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/10690b7"><code>10690b7</code></a> Upgrade: devdeps and deps to latest (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10622">#&#8203;10622</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/80c8598"><code>80c8598</code></a> Docs: gitignore syntax updates (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/8139">#&#8203;8139</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10776">#&#8203;10776</a>) (Gustavo Santana)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/cb946af"><code>cb946af</code></a> Chore: use meta.messages in some rules (1/4) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10764">#&#8203;10764</a>) (薛定谔的猫)</li>
</ul>
<hr />
<h3 id="v540httpsgithubcomeslinteslintreleasesv540"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.4.0"><code>v5.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.3.0…v5.4.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/a70909f"><code>a70909f</code></a> Docs: Add jscs-dev.github.io links (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10771">#&#8203;10771</a>) (Gustavo Santana)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/034690f"><code>034690f</code></a> Fix: no-invalid-meta crashes for non Object values (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10750">#&#8203;10750</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10753">#&#8203;10753</a>) (Sandeep Kumar Ranka)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/11a462d"><code>11a462d</code></a> Docs: Broken jscs.info URLs (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10732">#&#8203;10732</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10770">#&#8203;10770</a>) (Gustavo Santana)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/985567d"><code>985567d</code></a> Chore: rm unused dep string.prototype.matchall (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10756">#&#8203;10756</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f3d8454"><code>f3d8454</code></a> Update: Improve no-extra-parens error message (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10748">#&#8203;10748</a>) (Timo Tijhof)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/562a03f"><code>562a03f</code></a> Fix: consistent-docs-url crashes if meta.docs is empty (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10722">#&#8203;10722</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10749">#&#8203;10749</a>) (Sandeep Kumar Ranka)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6492233"><code>6492233</code></a> Chore: enable no-prototype-builtins in codebase (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10660">#&#8203;10660</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10664">#&#8203;10664</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/137140f"><code>137140f</code></a> Chore: use eslintrc overrides (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10677">#&#8203;10677</a>) (薛定谔的猫)</li>
</ul>
<hr />
<h3 id="v530httpsgithubcomeslinteslintreleasesv530"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.3.0"><code>v5.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.2.0…v5.3.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/dd6cb19"><code>dd6cb19</code></a> Docs: Updated no-return-await Rule Documentation (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9695">#&#8203;9695</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10699">#&#8203;10699</a>) (Marla Foreman)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6009239"><code>6009239</code></a> Chore: rename utils for consistency (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10727">#&#8203;10727</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6eb972c"><code>6eb972c</code></a> New: require-unicode-regexp rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9961">#&#8203;9961</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10698">#&#8203;10698</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5c5d64d"><code>5c5d64d</code></a> Fix: ignored-paths for Windows path (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10687">#&#8203;10687</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10691">#&#8203;10691</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5f6a765"><code>5f6a765</code></a> Build: ensure URL fragments remain in documentation links (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10717">#&#8203;10717</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10720">#&#8203;10720</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/863aa78"><code>863aa78</code></a> Docs: add another example for when not to use no-await-in-loop (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10714">#&#8203;10714</a>) (Valeri Karpov)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6e78b7d"><code>6e78b7d</code></a> Docs: remove links to terminated jscs.info domain (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10706">#&#8203;10706</a>) (Piotr Kuczynski)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d56c39d"><code>d56c39d</code></a> Fix: ESLint cache no longer stops autofix (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10679">#&#8203;10679</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10694">#&#8203;10694</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2cc3240"><code>2cc3240</code></a> New: add no-misleading-character-class (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10049">#&#8203;10049</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10511">#&#8203;10511</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/877f4b8"><code>877f4b8</code></a> Fix: The "../.." folder is always ignored (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10675">#&#8203;10675</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10682">#&#8203;10682</a>) (Sridhar)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5984820"><code>5984820</code></a> Chore: Move lib/file-finder.js to lib/util/ (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10559">#&#8203;10559</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10695">#&#8203;10695</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e37a593"><code>e37a593</code></a> Update: Fix incorrect default value for position (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10670">#&#8203;10670</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8084bfc"><code>8084bfc</code></a> Docs: change when not to use object spread (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10621">#&#8203;10621</a>) (Benny Powers)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7f496e2"><code>7f496e2</code></a> Chore: Update require path for ast-utils (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10693">#&#8203;10693</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/648a33a"><code>648a33a</code></a> Chore: reorganize code structure of utilities (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10599">#&#8203;10599</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10680">#&#8203;10680</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f026fe1"><code>f026fe1</code></a> Update: Fix 'function' in padding-line-between-statements (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10487">#&#8203;10487</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10676">#&#8203;10676</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/c2bb8bb"><code>c2bb8bb</code></a> Docs: Remove superfluous object option sample code (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10652">#&#8203;10652</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d34a13b"><code>d34a13b</code></a> Docs: add subheader in configuring/configuring-rules (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10686">#&#8203;10686</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d8aea28"><code>d8aea28</code></a> Chore: rm unnecessary plugin in eslint-config-eslint (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10685">#&#8203;10685</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9e76be7"><code>9e76be7</code></a> Update: indent comments w/ nearby code if no blank lines (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9733">#&#8203;9733</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10640">#&#8203;10640</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9e93d46"><code>9e93d46</code></a> New: add no-async-promise-executor rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10217">#&#8203;10217</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10661">#&#8203;10661</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5a2538c"><code>5a2538c</code></a> New: require-atomic-updates rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10405">#&#8203;10405</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10655">#&#8203;10655</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8b83d2b"><code>8b83d2b</code></a> Fix: always resolve default ignore patterns from CWD (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9227">#&#8203;9227</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10638">#&#8203;10638</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/acb6658"><code>acb6658</code></a> Fix: ESLint crash with prefer-object-spread (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10646">#&#8203;10646</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10649">#&#8203;10649</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/99fb7d3"><code>99fb7d3</code></a> Docs: fix misleading no-prototype-builtins description (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10666">#&#8203;10666</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/005b849"><code>005b849</code></a> Docs: fix outdated description of <code>baseConfig</code> option (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10657">#&#8203;10657</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/15a77c4"><code>15a77c4</code></a> Docs: fix broken links (fixes <a href="https://renovatebot.com/gh/eslint/eslint-jp/issues/6">eslint/eslint-jp#&#8203;6</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10658">#&#8203;10658</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/87cd344"><code>87cd344</code></a> Docs: Make marking a default option consistent with other rules (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10650">#&#8203;10650</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0cb5e3e"><code>0cb5e3e</code></a> Chore: Replace some function application with spread operators (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10645">#&#8203;10645</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b6daf0e"><code>b6daf0e</code></a> Docs: Remove superfluous section from no-unsafe-negation (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10648">#&#8203;10648</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e1a3cac"><code>e1a3cac</code></a> Chore: rm deprecated experimentalObjectRestSpread option in tests (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10647">#&#8203;10647</a>) (薛定谔的猫)</li>
</ul>
<hr />
<h3 id="v520httpsgithubcomeslinteslintreleasesv520"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.2.0"><code>v5.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.1.0…v5.2.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/81283d0"><code>81283d0</code></a> Update: Cache files that failed linting (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9948">#&#8203;9948</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10571">#&#8203;10571</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/13cc63e"><code>13cc63e</code></a> Upgrade: ignore@4.0.2 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10619">#&#8203;10619</a>) (Rouven Weßling)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/ac77a80"><code>ac77a80</code></a> Chore: Fixing a call to Object.assign.apply in Linter (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10629">#&#8203;10629</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/761f802"><code>761f802</code></a> Upgrade: eslint-plugin-node to 7.0.1 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10612">#&#8203;10612</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/c517b2a"><code>c517b2a</code></a> Build: fix npm run perf failing(fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10577">#&#8203;10577</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10607">#&#8203;10607</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e596939"><code>e596939</code></a> Chore: fix redundant equality check (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10617">#&#8203;10617</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9f93d5f"><code>9f93d5f</code></a> Docs: Updated Working with Custom Formatters (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9950">#&#8203;9950</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10592">#&#8203;10592</a>) (Marla Foreman)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9aaf195"><code>9aaf195</code></a> Chore: Extract lint result cache logic (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/9948">#&#8203;9948</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10562">#&#8203;10562</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/80b296e"><code>80b296e</code></a> Build: package.json update for eslint-config-eslint release (ESLint Jenkins)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e4e7ff2"><code>e4e7ff2</code></a> Chore: fix error message in eslint-config-eslint (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10588">#&#8203;10588</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/1e88170"><code>1e88170</code></a> Chore: Move lib/logging and lib/timing to lib/util/ (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10559">#&#8203;10559</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10579">#&#8203;10579</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/64dfa21"><code>64dfa21</code></a> Build: Fix prerelease logic in blog post generation (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10578">#&#8203;10578</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10581">#&#8203;10581</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0faf633"><code>0faf633</code></a> Chore: Simplify helper method in Linter tests (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10580">#&#8203;10580</a>) (Kevin Partington)</li>
</ul>
<hr />
<h3 id="v510httpsgithubcomeslinteslintreleasesv510"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.1.0">v5.1.0</a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.0.1…v5.1.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7328f99"><code>7328f99</code></a> Build: package.json update for eslint-config-eslint release (ESLint Jenkins)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b161f6b"><code>b161f6b</code></a> Build: Include prerelease install info in release blog post (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10463">#&#8203;10463</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b2df738"><code>b2df738</code></a> Fix: prefer-object-spread duplicated comma (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10512">#&#8203;10512</a>, fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10532">#&#8203;10532</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10524">#&#8203;10524</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d8c3a25"><code>d8c3a25</code></a> Fix: wrap-regex doesn't work in some expression(fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10573">#&#8203;10573</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10576">#&#8203;10576</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/114f42e"><code>114f42e</code></a> Docs: Clarify option defaults in max-lines-per-function docs (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10569">#&#8203;10569</a>) (Chris Harwood)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/63f36f7"><code>63f36f7</code></a> Fix: sort-keys in an object that contains spread (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10261">#&#8203;10261</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10495">#&#8203;10495</a>) (katerberg)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/601a5c4"><code>601a5c4</code></a> Fix: Prefer-const rule crashing on array destructuring (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10520">#&#8203;10520</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10527">#&#8203;10527</a>) (Michael Mason)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/143890a"><code>143890a</code></a> Update: Adjust grammar of error/warnings fixable (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10546">#&#8203;10546</a>) (Matt Mischuk)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8ee39c5"><code>8ee39c5</code></a> Chore: small refactor config-validator (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10565">#&#8203;10565</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/100f1be"><code>100f1be</code></a> Docs: add note about release issues to readme (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10572">#&#8203;10572</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/02efeac"><code>02efeac</code></a> Fix: do not fail on nested unknown operators (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10561">#&#8203;10561</a>) (Rubén Norte)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/92b19ca"><code>92b19ca</code></a> Chore: use eslintrc overrides(dogfooding) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10566">#&#8203;10566</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/076a6b6"><code>076a6b6</code></a> Docs: add actionable fix to no-irregular-whitespace (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10558">#&#8203;10558</a>) (Matteo Collina)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/de663ec"><code>de663ec</code></a> Docs: Only successfully linted files are cached (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9802">#&#8203;9802</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10557">#&#8203;10557</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f0e22fc"><code>f0e22fc</code></a> Upgrade: globals@11.7.0 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10497">#&#8203;10497</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8a2ff2c"><code>8a2ff2c</code></a> Docs:  adding a section about disable rules for some files (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10536">#&#8203;10536</a>) (Wellington Soares)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f22a3f8"><code>f22a3f8</code></a> Docs: fix a word in no-implied-eval (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10539">#&#8203;10539</a>) (Dan Homola)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/20d8bbd"><code>20d8bbd</code></a> Docs: add missing paragraph about "custom parsers" (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10547">#&#8203;10547</a>) (Pig Fang)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b7addf6"><code>b7addf6</code></a> Update: deprecate no-catch-shadow (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10466">#&#8203;10466</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10526">#&#8203;10526</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e862dc3"><code>e862dc3</code></a> Fix: Remove autofixer for no-debugger (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10242">#&#8203;10242</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10509">#&#8203;10509</a>) (Teddy Katz)</li>
</ul>
<hr />
<h3 id="v501httpsgithubcomeslinteslintreleasesv501"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.0.1"><code>v5.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.0.0…v5.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/196c102"><code>196c102</code></a> Fix: valid-jsdoc should allow optional returns for async (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10386">#&#8203;10386</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10480">#&#8203;10480</a>) (Mark Banner)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/4c823bd"><code>4c823bd</code></a> Docs: Fix max-lines-per-function correct code's max value (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10513">#&#8203;10513</a>) (Rhys Bower)</li>
</ul>
<hr />
<h3 id="v500httpsgithubcomeslinteslintreleasesv500"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.0.0"><code>v5.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.19.1…v5.0.0">Compare Source</a></p>
<p><a href="https://eslint.org/blog/2018/06/eslint-v5.0.0-released">Release blogpost</a></p>
<p><a href="https://eslint.org/docs/user-guide/migrating-to-5.0.0">Migration guide</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0feedfd"><code>0feedfd</code></a> New: Added max-lines-per-function rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9842">#&#8203;9842</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10188">#&#8203;10188</a>) (peteward44)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/daefbdb"><code>daefbdb</code></a> Upgrade: eslint-scope and espree to 4.0.0 (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10458">#&#8203;10458</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10500">#&#8203;10500</a>) (Brandon Mills)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/077358b"><code>077358b</code></a> Docs: no-process-exit: recommend process.exitCode (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10478">#&#8203;10478</a>) (Andres Kalle)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f93d6ff"><code>f93d6ff</code></a> Fix: do not fail on unknown operators from custom parsers (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10475">#&#8203;10475</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10476">#&#8203;10476</a>) (Rubén Norte)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/05343fd"><code>05343fd</code></a> Fix: add parens for yield statement (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10432">#&#8203;10432</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10468">#&#8203;10468</a>) (Pig Fang)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d477c5e"><code>d477c5e</code></a> Fix: check destructuring for "no-shadow-restricted-names" (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10467">#&#8203;10467</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10470">#&#8203;10470</a>) (Pig Fang)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7a7580b"><code>7a7580b</code></a> Update: Add considerPropertyDescriptor option to func-name-matching (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9078">#&#8203;9078</a>) (Dieter Luypaert)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e0a0418"><code>e0a0418</code></a> Fix: crash on optional catch binding (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10429">#&#8203;10429</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/de4dba9"><code>de4dba9</code></a> Docs: styling team members (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10460">#&#8203;10460</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5e453a3"><code>5e453a3</code></a> Docs: display team members in tables. (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10433">#&#8203;10433</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b1895eb"><code>b1895eb</code></a> Docs: Restore intentional spelling mistake (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10459">#&#8203;10459</a>) (Wilfred Hughes)</li>
</ul>
<hr />
<h3 id="v4191httpsgithubcomeslinteslintreleasesv4191"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.19.1"><code>v4.19.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.19.0…v4.19.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/3ff5d11"><code>3ff5d11</code></a> Fix: no-invalid-regexp not understand variable for flags (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10112">#&#8203;10112</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10113">#&#8203;10113</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/abc765c"><code>abc765c</code></a> Fix: object-curly-newline minProperties w/default export (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10101">#&#8203;10101</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10103">#&#8203;10103</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6f9e155"><code>6f9e155</code></a> Docs: Update ambiguous for…in example for guard-for-in (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10114">#&#8203;10114</a>) (CJ R)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0360cc2"><code>0360cc2</code></a> Chore: Adding debug logs on successful plugin loads (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10100">#&#8203;10100</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/a717c5d"><code>a717c5d</code></a> Chore: Adding log at beginning of unit tests in Makefile.js (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10102">#&#8203;10102</a>) (Kevin Partington)</li>
</ul>
<hr />
<h3 id="v4190httpsgithubcomeslinteslintreleasesv4190"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.19.0"><code>v4.19.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.18.2…v4.19.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/55a1593"><code>55a1593</code></a> Update: consecutive option for one-var (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/4680">#&#8203;4680</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9994">#&#8203;9994</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8d3814e"><code>8d3814e</code></a> Fix: false positive about ES2018 RegExp enhancements (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9893">#&#8203;9893</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10062">#&#8203;10062</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/935f4e4"><code>935f4e4</code></a> Docs: Clarify default ignoring of node_modules (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10092">#&#8203;10092</a>) (Matijs Brinkhuis)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/72ed3db"><code>72ed3db</code></a> Docs: Wrap <code>Buffer()</code> in backticks in <code>no-buffer-constructor</code> rule description (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10084">#&#8203;10084</a>) (Stephen Edgar)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/3aded2f"><code>3aded2f</code></a> Docs: Fix lodash typos, make spacing consistent (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10073">#&#8203;10073</a>) (Josh Smith)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e33bb64"><code>e33bb64</code></a> Chore: enable no-param-reassign on ESLint codebase (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10065">#&#8203;10065</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/66a1e9a"><code>66a1e9a</code></a> Docs: fix possible typo (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10060">#&#8203;10060</a>) (Vse Mozhet Byt)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2e68be6"><code>2e68be6</code></a> Update: give a node at least the indentation of its parent (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9995">#&#8203;9995</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10054">#&#8203;10054</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/72ca5b3"><code>72ca5b3</code></a> Update: Correctly indent JSXText with trailing linebreaks (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9878">#&#8203;9878</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10055">#&#8203;10055</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2a4c838"><code>2a4c838</code></a> Docs: Update ECMAScript versions in FAQ (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10047">#&#8203;10047</a>) (alberto)</li>
</ul>
<hr />
<h3 id="v4182httpsgithubcomeslinteslintreleasesv4182"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.18.2"><code>v4.18.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.18.1…v4.18.2">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6b71fd0"><code>6b71fd0</code></a> Fix: table@4.0.2, because 4.0.3 needs "ajv": "^6.0.1" (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10022">#&#8203;10022</a>) (Mathieu Seiler)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/3c697de"><code>3c697de</code></a> Chore: fix incorrect comment about linter.verify return value (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10030">#&#8203;10030</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9df8653"><code>9df8653</code></a> Chore: refactor parser-loading out of linter.verify (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10028">#&#8203;10028</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f6901d0"><code>f6901d0</code></a> Fix: remove catastrophic backtracking vulnerability (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10002">#&#8203;10002</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10019">#&#8203;10019</a>) (Jamie Davis)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e4f52ce"><code>e4f52ce</code></a> Chore: Simplify dataflow in linter.verify (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10020">#&#8203;10020</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/33177cd"><code>33177cd</code></a> Chore: make library files non-executable (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10021">#&#8203;10021</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/558ccba"><code>558ccba</code></a> Chore: refactor directive comment processing (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10007">#&#8203;10007</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/18e15d9"><code>18e15d9</code></a> Chore: avoid useless catch clauses that just rethrow errors (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10010">#&#8203;10010</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/a1c3759"><code>a1c3759</code></a> Chore: refactor populating configs with defaults in linter (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10006">#&#8203;10006</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/aea07dc"><code>aea07dc</code></a> Fix: Make max-len ignoreStrings ignore JSXText (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9954">#&#8203;9954</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9985">#&#8203;9985</a>) (Rachael Sim)</li>
</ul>
<hr />
<h3 id="v4181httpsgithubcomeslinteslintreleasesv4181"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.18.1"><code>v4.18.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.18.0…v4.18.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f417506"><code>f417506</code></a> Fix: ensure no-await-in-loop reports the correct node (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9992">#&#8203;9992</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9993">#&#8203;9993</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/3e99363"><code>3e99363</code></a> Docs: Fixed typo in key-spacing rule doc (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9987">#&#8203;9987</a>) (Jaid)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7c2cd70"><code>7c2cd70</code></a> Docs: deprecate experimentalObjectRestSpread (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9986">#&#8203;9986</a>) (Toru Nagashima)</li>
</ul>
<hr />
<h3 id="v4180httpsgithubcomeslinteslintreleasesv4180"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.18.0"><code>v4.18.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.17.0…v4.18.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/70f22f3"><code>70f22f3</code></a> Chore: Apply memoization to config creation within glob utils (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9944">#&#8203;9944</a>) (Kenton Jacobsen)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0e4ae22"><code>0e4ae22</code></a> Update: fix indent bug with binary operators/ignoredNodes (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9882">#&#8203;9882</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9951">#&#8203;9951</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/47ac478"><code>47ac478</code></a> Update: add named imports and exports for object-curly-newline (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9876">#&#8203;9876</a>) (Nicholas Chua)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e8efdd0"><code>e8efdd0</code></a> Fix: support Rest/Spread Properties (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9885">#&#8203;9885</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9943">#&#8203;9943</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f012b8c"><code>f012b8c</code></a> Fix: support Async iteration (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9891">#&#8203;9891</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9957">#&#8203;9957</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/74fa253"><code>74fa253</code></a> Docs: Clarify no-mixed-operators options (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9962">#&#8203;9962</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9964">#&#8203;9964</a>) (Ivan Hayes)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/426868f"><code>426868f</code></a> Docs: clean up key-spacing docs (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9900">#&#8203;9900</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9963">#&#8203;9963</a>) (Abid Uzair)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/4a6f22e"><code>4a6f22e</code></a> Update: support eslint-disable-* block comments (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/8781">#&#8203;8781</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9745">#&#8203;9745</a>) (Erin)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/777283b"><code>777283b</code></a> Docs: Propose fix typo for function (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9965">#&#8203;9965</a>) (John Eismeier)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/bf3d494"><code>bf3d494</code></a> Docs: Fix typo in max-len ignorePattern example. (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9956">#&#8203;9956</a>) (Tim Martin)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d64fbb4"><code>d64fbb4</code></a> Docs: fix typo in prefer-destructuring.md example (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9930">#&#8203;9930</a>) (Vse Mozhet Byt)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f8d343f"><code>f8d343f</code></a> Chore: Fix default issue template (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9946">#&#8203;9946</a>) (Kai Cataldo)</li>
</ul>
<hr />
<h3 id="v4170httpsgithubcomeslinteslintreleasesv4170"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.17.0"><code>v4.17.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.16.0…v4.17.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/1da1ada"><code>1da1ada</code></a> Update: Add "multiline" type to padding-line-between-statements (<a href="https://renovatebot.com/gh/eslint/eslint/issues/8668">#&#8203;8668</a>) (Matthew Bennett)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/bb213dc"><code>bb213dc</code></a> Chore: Use messageIds in some of the core rules (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9648">#&#8203;9648</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/1aa1970"><code>1aa1970</code></a> Docs: remove outdated rule naming convention (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9925">#&#8203;9925</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/3afaff6"><code>3afaff6</code></a> Docs: Add prefer-destructuring variable reassignment example (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9873">#&#8203;9873</a>) (LePirlouit)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d20f6b4"><code>d20f6b4</code></a> Fix: Typo in error message when running npm (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9866">#&#8203;9866</a>) (Maciej Kasprzyk)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/51ec6a7"><code>51ec6a7</code></a> Docs: Use GitHub Multiple PR/Issue templates (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9911">#&#8203;9911</a>) (Kai Cataldo)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/dc80487"><code>dc80487</code></a> Update: space-unary-ops uses astUtils.canTokensBeAdjacent (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9907">#&#8203;9907</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9906">#&#8203;9906</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/084351b"><code>084351b</code></a> Docs: Fix the messageId example (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9889">#&#8203;9889</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9892">#&#8203;9892</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9cbb487"><code>9cbb487</code></a> Docs: Mention the <code>globals</code> key in the no-undef docs (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9867">#&#8203;9867</a>) (Dan Dascalescu)</li>
</ul>
<hr />
<h3 id="v4160httpsgithubcomeslinteslintreleasesv4160"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.16.0"><code>v4.16.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.15.0…v4.16.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e26a25f"><code>e26a25f</code></a> Update: allow continue instead of if wrap in guard-for-in (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/7567">#&#8203;7567</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9796">#&#8203;9796</a>) (Michael Ficarra)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/af043eb"><code>af043eb</code></a> Update: Add NewExpression support to comma-style (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9591">#&#8203;9591</a>) (Frazer McLean)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/4f898c7"><code>4f898c7</code></a> Build: Fix JSDoc syntax errors (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9813">#&#8203;9813</a>) (Matija Marohnić)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/13bcf3c"><code>13bcf3c</code></a> Fix: Removing curly quotes in no-eq-null report message (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9852">#&#8203;9852</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b96fb31"><code>b96fb31</code></a> Docs: configuration hierarchy for CLIEngine options (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9526">#&#8203;9526</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9855">#&#8203;9855</a>) (PiIsFour)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8ccbdda"><code>8ccbdda</code></a> Docs: Clarify that -c configs merge with <code>.eslintrc.*</code> (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9535">#&#8203;9535</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9847">#&#8203;9847</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/978574f"><code>978574f</code></a> Docs: Fix examples for no-useless-escape (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9853">#&#8203;9853</a>) (Toru Kobayashi)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/cd5681d"><code>cd5681d</code></a> Chore: Deactivate consistent-docs-url in internal rules folder (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9815">#&#8203;9815</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2e87ddd"><code>2e87ddd</code></a> Docs: Sync messageId examples' style with other examples (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9816">#&#8203;9816</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/1d61930"><code>1d61930</code></a> Update: use doctrine range information in valid-jsdoc (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9831">#&#8203;9831</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/133336e"><code>133336e</code></a> Update: fix indent behavior on template literal arguments (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9061">#&#8203;9061</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9820">#&#8203;9820</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/ea1b15d"><code>ea1b15d</code></a> Fix: avoid crashing on malformed configuration comments (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9373">#&#8203;9373</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9819">#&#8203;9819</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/add1e70"><code>add1e70</code></a> Update: fix indent bug on comments in ternary expressions (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9729">#&#8203;9729</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9818">#&#8203;9818</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6a5cd32"><code>6a5cd32</code></a> Fix: prefer-destructuring error with computed properties (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9784">#&#8203;9784</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9817">#&#8203;9817</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/601f851"><code>601f851</code></a> Docs: Minor modification to code comments for clarity (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9821">#&#8203;9821</a>) (rgovind92)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b9da067"><code>b9da067</code></a> Docs: fix misleading info about RuleTester column numbers (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9830">#&#8203;9830</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2cf4522"><code>2cf4522</code></a> Update: Rename and deprecate object-property-newline option (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9570">#&#8203;9570</a>) (Jonathan Pool)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/acde640"><code>acde640</code></a> Docs: Add ES 2018 to Configuring ESLint (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9829">#&#8203;9829</a>) (Kai Cataldo)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/ccfce15"><code>ccfce15</code></a> Docs: Minor tweaks to working with rules page (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9824">#&#8203;9824</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/54b329a"><code>54b329a</code></a> Docs: fix substitution of {{ name }} (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9822">#&#8203;9822</a>) (Andres Kalle)</li>
</ul>
<hr />
<h3 id="v4150httpsgithubcomeslinteslintreleasesv4150"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.15.0"><code>v4.15.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.14.0…v4.15.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6ab04b5"><code>6ab04b5</code></a> New: Add context.report({ messageId }) (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/6740">#&#8203;6740</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9165">#&#8203;9165</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/fc7f404"><code>fc7f404</code></a> Docs: add url to each of the rules (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/6582">#&#8203;6582</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9788">#&#8203;9788</a>) (Patrick McElhaney)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/fc44da9"><code>fc44da9</code></a> Docs: fix sort-imports rule block language (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9805">#&#8203;9805</a>) (ferhat elmas)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/65f0176"><code>65f0176</code></a> New: CLIEngine#getRules() (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/6582">#&#8203;6582</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9782">#&#8203;9782</a>) (Patrick McElhaney)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/c64195f"><code>c64195f</code></a> Update: More detailed assert message for rule-tester (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9769">#&#8203;9769</a>) (Weijia Wang)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9fcfabf"><code>9fcfabf</code></a> Fix: no-extra-parens false positive (fixes: <a href="https://renovatebot.com/gh/eslint/eslint/issues/9755">#&#8203;9755</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9795">#&#8203;9795</a>) (Erin)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/61e5fa0"><code>61e5fa0</code></a> Docs: Add table of contents to Node.js API docs (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9785">#&#8203;9785</a>) (Patrick McElhaney)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/4c87f42"><code>4c87f42</code></a> Fix: incorrect error messages of no-unused-vars (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9774">#&#8203;9774</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9791">#&#8203;9791</a>) (akouryy)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/bbabf34"><code>bbabf34</code></a> Update: add <code>ignoreComments</code> option to <code>indent</code> rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9018">#&#8203;9018</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9752">#&#8203;9752</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/db431cb"><code>db431cb</code></a> Docs: HTTP -&gt; HTTPS (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9768">#&#8203;9768</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9768">#&#8203;9768</a>) (Ronald Eddy Jr)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/cbf0fb9"><code>cbf0fb9</code></a> Docs: describe how to feature-detect scopeManager/visitorKeys support (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9764">#&#8203;9764</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f7dcb70"><code>f7dcb70</code></a> Docs: Add note about "patch release pending" label to maintainer guide (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9763">#&#8203;9763</a>) (Teddy Katz)</li>
</ul>
<hr />
<h3 id="v4140httpsgithubcomeslinteslintreleasesv4140"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v4.14.0"><code>v4.14.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.13.1…v4.14.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/be2f57e"><code>be2f57e</code></a> Update: support separate requires in one-var. (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/6175">#&#8203;6175</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9441">#&#8203;9441</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/370d614"><code>370d614</code></a> Docs: Fix typos (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9751">#&#8203;9751</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8196c45"><code>8196c45</code></a> Chore: Reorganize CLI options and associated docs (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9758">#&#8203;9758</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/75c7419"><code>75c7419</code></a> Update: Logical-and is counted in <code>complexity</code> rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/8535">#&#8203;8535</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9754">#&#8203;9754</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/eb4b1e0"><code>eb4b1e0</code></a> Docs: reintroduce misspelling in <code>valid-typeof</code> example (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9753">#&#8203;9753</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/ae51eb2"><code>ae51eb2</code></a> New: Add allowImplicit option to array-callback-return (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/8539">#&#8203;8539</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9344">#&#8203;9344</a>) (James C. Davis)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e9d5dfd"><code>e9d5dfd</code></a> Docs: improve no-extra-parens formatting (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9747">#&#8203;9747</a>) (Rich Trott)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/37d066c"><code>37d066c</code></a> Chore: Add unit tests for overrides glob matching. (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9744">#&#8203;9744</a>) (Robert Jackson)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/805a94e"><code>805a94e</code></a> Chore: Fix typo in CLIEngine test name (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9741">#&#8203;9741</a>) (<a href="https://renovatebot.com/gh/scriptdaemon">@&#8203;scriptdaemon</a>)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/1c2aafd"><code>1c2aafd</code></a> Update: Improve parser integrations (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/8392">#&#8203;8392</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/8755">#&#8203;8755</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/4ddc131"><code>4ddc131</code></a> Upgrade: debug@^3.1.0 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9731">#&#8203;9731</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f252c19"><code>f252c19</code></a> Docs: Make the lint message <code>source</code> property a little more subtle (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9735">#&#8203;9735</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5a5c23c"><code>5a5c23c</code></a> Docs: fix the link to contributing page (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9727">#&#8203;9727</a>) (Victor Hom)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f44ce11"><code>f44ce11</code></a> Docs: change beginner to good first issue label text (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9726">#&#8203;9726</a>) (Victor Hom)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/14baa2e"><code>14baa2e</code></a> Chore: improve arrow-body-style error message (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/5498">#&#8203;5498</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9718">#&#8203;9718</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f819920"><code>f819920</code></a> Docs: fix typos (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9723">#&#8203;9723</a>) (Thomas Broadley)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/43d4ba8"><code>43d4ba8</code></a> Fix: false positive on rule<code>lines-between-class-members</code> (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9665">#&#8203;9665</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9680">#&#8203;9680</a>) (sakabar)</li>
</ul>
<hr />
<h3 id="v4131httpsgithubcomeslinteslintreleases