### PR TITLE
Update dependency typescript-eslint-parser to v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3735,20 +3735,11 @@
                 "lodash.escape": "^3.0.0"
             }
         },
-        "lodash.tostring": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-            "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
-            "dev": true
-        },
         "lodash.unescape": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
-            "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
-            "dev": true,
-            "requires": {
-                "lodash.tostring": "^4.0.0"
-            }
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+            "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+            "dev": true
         },
         "longest-streak": {
             "version": "2.0.2",
@@ -9347,13 +9338,21 @@
             "dev": true
         },
         "typescript-eslint-parser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-2.1.0.tgz",
-            "integrity": "sha1-aoTIP6uJtBIkdyfCMszAWqyuESo=",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-18.0.0.tgz",
+            "integrity": "sha512-Pn/A/Cw9ysiXSX5U1xjBmPQlxtWGV2o7jDNiH/u7KgBO2yC/y37wNFl2ogSrGZBQFuglLzGq0Xl0Bt31Jv44oA==",
             "dev": true,
             "requires": {
-                "lodash.unescape": "4.0.0",
-                "object-assign": "^4.0.1"
+                "lodash.unescape": "4.0.1",
+                "semver": "5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "dev": true
+                }
             }
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "mocha": "3.2.0",
         "renovate": "13.67.1",
         "typescript": "2.2.2",
-        "typescript-eslint-parser": "2.1.0",
+        "typescript-eslint-parser": "18.0.0",
         "vsce": "1.20.0",
         "vscode": "1.1.0",
         "watch": "1.0.2"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>typescript-eslint-parser</code> (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser">source</a>) from <code>v2.1.0</code> to <code>v18.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v1800httpsgithubcomeslinttypescript-eslint-parserreleasesv1800"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v18.0.0"><code>v18.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v17.0.1…v18.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/16d1a78"><code>16d1a78</code></a> Breaking: Support TypeScript 3.0 (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/504">#&#8203;504</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/7461462"><code>7461462</code></a> Fix: remove unnecessary TypeRef wrapper for ImportType (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/507">#&#8203;507</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/508">#&#8203;508</a>) (Ika)</li>
</ul>
<hr />
<h3 id="v1701httpsgithubcomeslinttypescript-eslint-parserreleasesv1701"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v17.0.1"><code>v17.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v17.0.0…v17.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/f1d7de3"><code>f1d7de3</code></a> Chore: Replace removed API with public flags (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/498">#&#8203;498</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/505">#&#8203;505</a>) (Texas Toland)</li>
</ul>
<hr />
<h3 id="v1700httpsgithubcomeslinttypescript-eslint-parserreleasesv1700"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v17.0.0"><code>v17.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v16.0.1…v17.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/117800d"><code>117800d</code></a> Fix: support JSXSpreadChild (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/500">#&#8203;500</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/501">#&#8203;501</a>) (Ika)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/6eec85b"><code>6eec85b</code></a> Breaking: Remove "Experimental" from rest and spread (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/428">#&#8203;428</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/429">#&#8203;429</a>) (Lucas Duailibe)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/42f29a1"><code>42f29a1</code></a> Fix: error on multiple super classes (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/493">#&#8203;493</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/494">#&#8203;494</a>) (Ika)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/11d9169"><code>11d9169</code></a> Breaking: always set optional on ClassProperty (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/472">#&#8203;472</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/491">#&#8203;491</a>) (Ika)</li>
</ul>
<hr />
<h3 id="v1601httpsgithubcomeslinttypescript-eslint-parserreleasesv1601"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v16.0.1"><code>v16.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v16.0.0…v16.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/bc83c6a"><code>bc83c6a</code></a> Chore: Do not run integration tests within npm test (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/db62d63"><code>db62d63</code></a> Fix: Snapshot all ecma-features fixtures (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/495">#&#8203;495</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/3c1fab0"><code>3c1fab0</code></a> Fix: support ImportMeta (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/489">#&#8203;489</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/490">#&#8203;490</a>) (Ika)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/6611535"><code>6611535</code></a> Chore: Loosen node version requirement in package.json (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/482">#&#8203;482</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/484">#&#8203;484</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/27f39cc"><code>27f39cc</code></a> Chore: Powerful integration tests and improved README (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/483">#&#8203;483</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v1600httpsgithubcomeslinttypescript-eslint-parserreleasesv1600"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v16.0.0"><code>v16.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v15.0.1…v16.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/009336d"><code>009336d</code></a> Breaking: Set minimum node version to 6 (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/481">#&#8203;481</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/9316b23"><code>9316b23</code></a> Breaking: Support TypeScript 2.9 (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/480">#&#8203;480</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v1501httpsgithubcomeslinttypescript-eslint-parserreleasesv1501"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v15.0.1"><code>v15.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v15.0.0…v15.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/891cee9"><code>891cee9</code></a> Fix: decorators removed on interface declarations (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/478">#&#8203;478</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/479">#&#8203;479</a>) (Muhanad Rabie)</li>
</ul>
<hr />
<h3 id="v1500httpsgithubcomeslinttypescript-eslint-parserreleasesv1500"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v15.0.0"><code>v15.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v14.0.0…v15.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/e572416"><code>e572416</code></a> Breaking: Support TypeScript 2.8 (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/453">#&#8203;453</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/454">#&#8203;454</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v1400httpsgithubcomeslinttypescript-eslint-parserreleasesv1400"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v14.0.0"><code>v14.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v13.0.0…v14.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/439ea24"><code>439ea24</code></a> New: Support Definite Assignment (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/424">#&#8203;424</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/432">#&#8203;432</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/adc0b1b"><code>adc0b1b</code></a> Breaking: Remove all tokens inside comments from tokens array (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/422">#&#8203;422</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/423">#&#8203;423</a>) (Kai Cataldo)</li>
</ul>
<hr />
<h3 id="v1300httpsgithubcomeslinttypescript-eslint-parserreleasesv1300"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v13.0.0"><code>v13.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v12.0.0…v13.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/fb5e4c4"><code>fb5e4c4</code></a> Breaking: Support TypeScript 2.7 (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/442">#&#8203;442</a>,<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/426">#&#8203;426</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/447">#&#8203;447</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/bd9c12f"><code>bd9c12f</code></a> Docs: Update Known Issues section of README (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/440">#&#8203;440</a>) (Kepler Sticka-Jones)</li>
</ul>
<hr />
<h3 id="v1200httpsgithubcomeslinttypescript-eslint-parserreleasesv1200"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v12.0.0"><code>v12.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v11.0.0…v12.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/6ce4cd8"><code>6ce4cd8</code></a> Breaking: Properly categorize constructors with no body (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/427">#&#8203;427</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/e94ede3"><code>e94ede3</code></a> Docs: Sets default code block language in issue template to "ts" (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/421">#&#8203;421</a>) (Marius Schulz)</li>
</ul>
<hr />
<h3 id="v1100httpsgithubcomeslinttypescript-eslint-parserreleasesv1100"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v11.0.0"><code>v11.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v10.0.0…v11.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/6698042"><code>6698042</code></a> Breaking: No prefix on FnDec within namespace (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/127">#&#8203;127</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/413">#&#8203;413</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/aec31cb"><code>aec31cb</code></a> Breaking: Implement parseForESLint() function (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/412">#&#8203;412</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v1000httpsgithubcomeslinttypescript-eslint-parserreleasesv1000"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v10.0.0"><code>v10.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v9.0.1…v10.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/59a37f4"><code>59a37f4</code></a> Breaking: Updates to AST node types of some TSNodes (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/386">#&#8203;386</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/388">#&#8203;388</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/627355e"><code>627355e</code></a> Chore: Introduce integration tests (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/411">#&#8203;411</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/b4d22e7"><code>b4d22e7</code></a> Chore: No package-lock like other ESLint repos (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/409">#&#8203;409</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v901httpsgithubcomeslinttypescript-eslint-parserreleasesv901"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v9.0.1"><code>v9.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v9.0.0…v9.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/153cdb8"><code>153cdb8</code></a> Fix: Calculate end position of TypeInstantiation (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/406">#&#8203;406</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/405">#&#8203;405</a>) (Lucas Duailibe)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/678907b"><code>678907b</code></a> Fix: Explicitly convert AbstractKeyword (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/407">#&#8203;407</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/408">#&#8203;408</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v900httpsgithubcomeslinttypescript-eslint-parserreleasesv900"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v9.0.0"><code>v9.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v8.0.1…v9.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/46479e8"><code>46479e8</code></a> Breaking: Support TypeScript 2.6 (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/394">#&#8203;394</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/397">#&#8203;397</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v801httpsgithubcomeslinttypescript-eslint-parserreleasesv801"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v8.0.1"><code>v8.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v8.0.0…v8.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/0401ffc"><code>0401ffc</code></a> Fix: Calculate typeArguments loc data correctly if empty (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/395">#&#8203;395</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/396">#&#8203;396</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/a214f71"><code>a214f71</code></a> Chore: Add a way to test TSX specific issues (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/376">#&#8203;376</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/398">#&#8203;398</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/9c71a62"><code>9c71a62</code></a> Fix: add missing TSSymbolKeyword type (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/385">#&#8203;385</a>) (Ika)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/e10aab8"><code>e10aab8</code></a> Chore: Refactor alignment tests, now on by default (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/387">#&#8203;387</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/9e17d0b"><code>9e17d0b</code></a> Chore: Minor cleanup, fix jQuery foundation copyright (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/383">#&#8203;383</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v800httpsgithubcomeslinttypescript-eslint-parserreleasesv800"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v8.0.0"><code>v8.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v7.0.0…v8.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/9877e98"><code>9877e98</code></a> Breaking: Support TypeScript 2.5 (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/368">#&#8203;368</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/369">#&#8203;369</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/370">#&#8203;370</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/5b49870"><code>5b49870</code></a> Fix: Location data for typeAnnotations (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/378">#&#8203;378</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v700httpsgithubcomeslinttypescript-eslint-parserreleasesv700"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v7.0.0"><code>v7.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v6.0.1…v7.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/01c34f4"><code>01c34f4</code></a> Fix: Ensure exports applied to TSModuleDeclaration (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/375">#&#8203;375</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/38bd1ae"><code>38bd1ae</code></a> Breaking: Check for isTypeKeyword in type params (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/373">#&#8203;373</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/374">#&#8203;374</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/3727956"><code>3727956</code></a> Breaking: Handle TSModuleDeclaration and refactor (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/371">#&#8203;371</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/372">#&#8203;372</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/d67ee6c"><code>d67ee6c</code></a> Fix: Typo in TSExportAssignment node type (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/367">#&#8203;367</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v601httpsgithubcomeslinttypescript-eslint-parserreleasesv601"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v6.0.1"><code>v6.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v6.0.0…v6.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/7bcc0d6"><code>7bcc0d6</code></a> Fix: Ensure modifiers are applied to enums (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/365">#&#8203;365</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/366">#&#8203;366</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v600httpsgithubcomeslinttypescript-eslint-parserreleasesv600"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v6.0.0"><code>v6.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v5.0.1…v6.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/32c0cc8"><code>32c0cc8</code></a> Breaking: Explicitly handle TSEnumDeclaration (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/345">#&#8203;345</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/364">#&#8203;364</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/5f741a9"><code>5f741a9</code></a> Fix: Allow other orderings of implements/extends clauses (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/361">#&#8203;361</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/363">#&#8203;363</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/f5bd145"><code>f5bd145</code></a> Chore: Breakout and label TS-specific AST comparison tests (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/360">#&#8203;360</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/f6e56b3"><code>f6e56b3</code></a> Chore: Build out AST comparison tests and categorize issues (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/358">#&#8203;358</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/ab4e05e"><code>ab4e05e</code></a> Breaking: Only add .implements/.accessibility/.decorators if truthy (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/354">#&#8203;354</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/275897b"><code>275897b</code></a> Fix: Location data for methods and constructors (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/357">#&#8203;357</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/5fce5e7"><code>5fce5e7</code></a> Fix: Exp. operator assignment is AssignmentExpression (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/355">#&#8203;355</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/356">#&#8203;356</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/67971de"><code>67971de</code></a> Fix: Include newlines at the end of source in AST (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/352">#&#8203;352</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/353">#&#8203;353</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/8406209"><code>8406209</code></a> Fix: Remove start and end values from JSX tokens (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/341">#&#8203;341</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/351">#&#8203;351</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v501httpsgithubcomeslinttypescript-eslint-parserreleasesv501"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v5.0.1"><code>v5.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v5.0.0…v5.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/81e20c0"><code>81e20c0</code></a> Fix: Only warn about an unsupported TypeScript version once (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/347">#&#8203;347</a>) (Jed Fox)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/5e22fac"><code>5e22fac</code></a> Chore: AST alignment testing against Babylon (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/342">#&#8203;342</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v500httpsgithubcomeslinttypescript-eslint-parserreleasesv500"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v5.0.0"><code>v5.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v4.0.0…v5.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/271b4f1"><code>271b4f1</code></a> New: Support TypeScript 2.4 (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/321">#&#8203;321</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/322">#&#8203;322</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/326">#&#8203;326</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/ea6c3bb"><code>ea6c3bb</code></a> Breaking: Use TSTypeReference for TypeParameters (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/340">#&#8203;340</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/a9ca775"><code>a9ca775</code></a> Fix: Use name 'this' in JSXMemberExpression (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/337">#&#8203;337</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/338">#&#8203;338</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/ef2687b"><code>ef2687b</code></a> Fix: Handle assignment within property destructuring (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/332">#&#8203;332</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/336">#&#8203;336</a>) (James Henry)</li>
</ul>
<hr />
<h3 id="v400httpsgithubcomeslinttypescript-eslint-parserreleasesv400"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v4.0.0"><code>v4.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v3.0.0…v4.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/6a612cd"><code>6a612cd</code></a> Breaking: Include type annotation range for Identifiers (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/314">#&#8203;314</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/319">#&#8203;319</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/074a64f"><code>074a64f</code></a> Fix: Arrow function body should be ObjectExpression (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/331">#&#8203;331</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/334">#&#8203;334</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/fb66f61"><code>fb66f61</code></a> Fix: Unescape string literal identifiers (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/328">#&#8203;328</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/330">#&#8203;330</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/9cab9d3"><code>9cab9d3</code></a> Breaking: Remove TypeAnnotation wrapper from constraint (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/325">#&#8203;325</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/b255499"><code>b255499</code></a> New: Provider loggerFn option to configure logging (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/323">#&#8203;323</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/324">#&#8203;324</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/0540298"><code>0540298</code></a> Fix: Calculate correct type parameter range (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/316">#&#8203;316</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/320">#&#8203;320</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/4938c2c"><code>4938c2c</code></a> Fix: Ensure JSX tag names are JSXIdentifiers (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/315">#&#8203;315</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/318">#&#8203;318</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/1f20557"><code>1f20557</code></a> Fix: Use TSExportAssignment node type (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/304">#&#8203;304</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/317">#&#8203;317</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/b26cda1"><code>b26cda1</code></a> Fix: Use TSNullKeyword for null type instead of Literal (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/313">#&#8203;313</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/9037dc5"><code>9037dc5</code></a> Chore: Add node 8 to .travis.yml (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/312">#&#8203;312</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/8062515"><code>8062515</code></a> Chore: Refactor tests to assert snapshots not JSON (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/311">#&#8203;311</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/2ad791b"><code>2ad791b</code></a> Fix: Add name to JSXIdentifier when converting ThisKeyword (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/307">#&#8203;307</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/310">#&#8203;310</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/519907e"><code>519907e</code></a> Breaking: Use ESTree export node types in modules (fixes# 263) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/265">#&#8203;265</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/c4b0b64"><code>c4b0b64</code></a> Fix: Label readonly class properties (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/302">#&#8203;302</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/303">#&#8203;303</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/bffd6cc"><code>bffd6cc</code></a> Fix: Add more tests for destructuring and spread (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/306">#&#8203;306</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/308">#&#8203;308</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/f7c9246"><code>f7c9246</code></a> Chore: Fix typo in comment (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/305">#&#8203;305</a>) (Jeremy Attali)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/3dcba7d"><code>3dcba7d</code></a> Breaking: Change isReadonly to readonly (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/284">#&#8203;284</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/285">#&#8203;285</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/bc9225f"><code>bc9225f</code></a> Chore: Replace mocha (istanbul, chai, leche) with Jest (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/300">#&#8203;300</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/8744577"><code>8744577</code></a> Breaking: Decorator ESTree compliance, always convert (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/250">#&#8203;250</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/293">#&#8203;293</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/dd6404a"><code>dd6404a</code></a> Breaking: Convert Signature types to be more ESTree like (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/262">#&#8203;262</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/264">#&#8203;264</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/379dcaf"><code>379dcaf</code></a> Fix: Only set optional property on certain node property (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/289">#&#8203;289</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/292">#&#8203;292</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/89f8561"><code>89f8561</code></a> Fix: Label static and export in TSParameterProperty (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/286">#&#8203;286</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/301">#&#8203;301</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/992f1fa"><code>992f1fa</code></a> Fix: Unescape type parameter names (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/296">#&#8203;296</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/298">#&#8203;298</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/5ed8573"><code>5ed8573</code></a> Fix: Async generator method should be labeled (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/297">#&#8203;297</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/299">#&#8203;299</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/31ad3c4"><code>31ad3c4</code></a> Fix: Create RegExp object for RegExp literals (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/287">#&#8203;287</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/291">#&#8203;291</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/525a544"><code>525a544</code></a> Fix: Set node type to ExperimentalRestProperty (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/276">#&#8203;276</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/279">#&#8203;279</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/eb32fed"><code>eb32fed</code></a> Fix: Convert type guards (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/282">#&#8203;282</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/283">#&#8203;283</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/b7220fd"><code>b7220fd</code></a> New: Create option to enable JSXText node type (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/266">#&#8203;266</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/272">#&#8203;272</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/6dd3696"><code>6dd3696</code></a> Fix: Add exponentiation operators (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/280">#&#8203;280</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/281">#&#8203;281</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/3491b4b"><code>3491b4b</code></a> Fix: Replace JSXMemberExpression with TSQualifiedName (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/257">#&#8203;257</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/258">#&#8203;258</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/b4eb0b5"><code>b4eb0b5</code></a> Fix: Convert range and line number corretly in JSX literals (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/277">#&#8203;277</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/3f9f41c"><code>3f9f41c</code></a> Fix: wrap interface in ExportNamedDeclaration if necessary (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/269">#&#8203;269</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/270">#&#8203;270</a>) (Danny Martini)</li>
</ul>
<hr />
<h3 id="v300httpsgithubcomeslinttypescript-eslint-parserreleasesv300"><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/releases/v3.0.0">v3.0.0</a></h3>
<p><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/compare/v2.1.0…v3.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/6b56bfe"><code>6b56bfe</code></a> Fix: Use correct starting range and loc for JSXText tokens (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/227">#&#8203;227</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/271">#&#8203;271</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/f5fcc87"><code>f5fcc87</code></a> Breaking: Allow comment scanner to rescan tokens (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/216">#&#8203;216</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/219">#&#8203;219</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/f836bb9"><code>f836bb9</code></a> Chore: Refactor the codebase (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/220">#&#8203;220</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/261">#&#8203;261</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/aade6bd"><code>aade6bd</code></a> Chore: Update README with list of known issues (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/247">#&#8203;247</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/c8e881a"><code>c8e881a</code></a> Breaking: Normalize type parameters (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/197">#&#8203;197</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/196">#&#8203;196</a>) (Rasmus Eneman)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/d37bf04"><code>d37bf04</code></a> Fix: Type parameter start location calculation (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/260">#&#8203;260</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/259">#&#8203;259</a>) (Igor Oleinikov)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/1a97650"><code>1a97650</code></a> Fix: Handle case where class has extends but no super class (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/249">#&#8203;249</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/254">#&#8203;254</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/00ad71d"><code>00ad71d</code></a> Fix: add <code>instanceof</code> to ast-converter (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/252">#&#8203;252</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/251">#&#8203;251</a>) (Danny Arnold)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/2989f8b"><code>2989f8b</code></a> Upgrade: Update semver package (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/246">#&#8203;246</a>) (Simen Bekkhus)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/b1efe69"><code>b1efe69</code></a> Breaking: Change how interface node gets converted (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/201">#&#8203;201</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/241">#&#8203;241</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/e311620"><code>e311620</code></a> Fix: Set await property on async iterators (for await) (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/236">#&#8203;236</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/239">#&#8203;239</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/a294afa"><code>a294afa</code></a> Fix: Set async on async FunctionExpressions (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/244">#&#8203;244</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/245">#&#8203;245</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/7c00f16"><code>7c00f16</code></a> Chore: Add tests for object spread and async generator (refs <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/236">#&#8203;236</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/237">#&#8203;237</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/7b69bc9"><code>7b69bc9</code></a> Fix: Label abstract class properties (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/234">#&#8203;234</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/238">#&#8203;238</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/a330ec6"><code>a330ec6</code></a> New: Add support for default type parameters (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/235">#&#8203;235</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/240">#&#8203;240</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/e1ef800"><code>e1ef800</code></a> Fix: Support superTypeParameters (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/242">#&#8203;242</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/243">#&#8203;243</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/65c2e0a"><code>65c2e0a</code></a> Breaking: Support TypeScript 2.3 (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/232">#&#8203;232</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/233">#&#8203;233</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/15f1173"><code>15f1173</code></a> Fix: Use TSAbsractMethodDefinition for abstract constructor (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/228">#&#8203;228</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/229">#&#8203;229</a>) (Lucas Azzola)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/8fb71d2"><code>8fb71d2</code></a> Breaking: Add .body to TSModuleBlock nodes (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/217">#&#8203;217</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/218">#&#8203;218</a>) (Philipp A)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/471f403"><code>471f403</code></a> Chore: Remove before_script from .travis.yml (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/231">#&#8203;231</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/230">#&#8203;230</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/9397c5c"><code>9397c5c</code></a> Chore: Cleanup Makefile (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/221">#&#8203;221</a>) (Reyad Attiyat)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/dd57f81"><code>dd57f81</code></a> Update: Open TS peerDependency, warn non-supported version (fixes <a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/167">#&#8203;167</a>) (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/193">#&#8203;193</a>) (James Henry)</li>
<li><a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/commit/a37d5ed"><code>a37d5ed</code></a> Fix: Wrap any parameter with modifiers, not just in constructors (<a href="https://renovatebot.com/gh/eslint/typescript-eslint-parser/issues/214">#&#8203;214</a>) (Rasmus Eneman)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>