### PR TITLE
Update dependency vsce to v1.49.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9226,9 +9226,9 @@
             }
         },
         "vsce": {
-            "version": "1.48.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.48.0.tgz",
-            "integrity": "sha512-1qJn6QLRTu26FIvvMbK/gzHLLdxJVTg9CUTSnCjJHObCCF5CQ0F3FUv7t+5cT7i0J5v5YljrsRY09u7dPBcEnA==",
+            "version": "1.49.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.49.1.tgz",
+            "integrity": "sha512-lKAK24hoD27eVD9rcg6l67aSCELflOinupg+MgPEAvE+Q/WdehtE/xYgF5Zx/KUkDjoe31zM6jr0PdwkEmqf2Q==",
             "dev": true,
             "requires": {
                 "cheerio": "^1.0.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "renovate": "13.69.0",
         "typescript": "3.0.3",
         "typescript-eslint-parser": "18.0.0",
-        "vsce": "1.48.0",
+        "vsce": "1.49.1",
         "vscode": "1.1.21",
         "watch": "1.0.2"
     }


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>vsce</code> (<a href="https://code.visualstudio.com">homepage</a>, <a href="https://renovatebot.com/gh/Microsoft/vsce">source</a>) from <code>v1.48.0</code> to <code>v1.49.1</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v1491httpsgithubcommicrosoftvscecomparev1490v1491"><a href="https://renovatebot.com/gh/Microsoft/vsce/compare/v1.49.0…v1.49.1"><code>v1.49.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/Microsoft/vsce/compare/v1.49.0…v1.49.1">Compare Source</a></p>
<hr />
<h3 id="v1490httpsgithubcommicrosoftvscecomparev1480v1490"><a href="https://renovatebot.com/gh/Microsoft/vsce/compare/v1.48.0…v1.49.0"><code>v1.49.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/Microsoft/vsce/compare/v1.48.0…v1.49.0">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>