### PR TITLE
Update dependency vsce to v1.49.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9237,9 +9237,9 @@
             }
         },
         "vsce": {
-            "version": "1.49.1",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.49.1.tgz",
-            "integrity": "sha512-lKAK24hoD27eVD9rcg6l67aSCELflOinupg+MgPEAvE+Q/WdehtE/xYgF5Zx/KUkDjoe31zM6jr0PdwkEmqf2Q==",
+            "version": "1.49.2",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.49.2.tgz",
+            "integrity": "sha512-CK9ruBy03c3GkZnoWHvqIUgN8CYc74PS4U6QmrQC2+QHDbqHLkdDaS0i25ZfhY/mYlrgB3JrDau0o2bhPsFIrA==",
             "dev": true,
             "requires": {
                 "cheerio": "^1.0.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "renovate": "13.72.3",
         "typescript": "3.0.3",
         "typescript-eslint-parser": "18.0.0",
-        "vsce": "1.49.1",
+        "vsce": "1.49.2",
         "vscode": "1.1.21",
         "watch": "1.0.2"
     }


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>vsce</code> (<a href="https://code.visualstudio.com">homepage</a>, <a href="https://renovatebot.com/gh/Microsoft/vsce">source</a>) from <code>v1.49.1</code> to <code>v1.49.2</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v1492httpsgithubcommicrosoftvscecomparev1491v1492"><a href="https://renovatebot.com/gh/Microsoft/vsce/compare/v1.49.1…v1.49.2"><code>v1.49.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/Microsoft/vsce/compare/v1.49.1…v1.49.2">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>