### PR TITLE
Update dependency eslint-config-prettier to v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,9 +1326,9 @@
             }
         },
         "eslint-config-prettier": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.0.1.tgz",
-            "integrity": "sha512-vA0TB8HCx/idHXfKHYcg9J98p0Q8nkfNwNAoP7e+ywUidn6ScaFS5iqncZAHPz+/a0A/tp657ulFHFx/2JDP4Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.1.0.tgz",
+            "integrity": "sha512-QYGfmzuc4q4J6XIhlp8vRKdI/fI0tQfQPy1dME3UOLprE+v4ssH/3W9LM2Q7h5qBcy5m0ehCrBDU2YF8q6OY8w==",
             "dev": true,
             "requires": {
                 "get-stdin": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@types/node": "7.0.12",
         "@types/ramda": "0.25.38",
         "eslint": "5.6.0",
-        "eslint-config-prettier": "3.0.1",
+        "eslint-config-prettier": "3.1.0",
         "eslint-plugin-prettier": "2.6.2",
         "mocha": "5.2.0",
         "renovate": "13.73.2",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>eslint-config-prettier</code> (<a href="https://renovatebot.com/gh/prettier/eslint-config-prettier">source</a>) from <code>v3.0.1</code> to <code>v3.1.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v310httpsgithubcomprettiereslint-config-prettierblobmasterchangelogmdversion-310-2018-09-22"><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/blob/master/CHANGELOG.md#Version-310-2018-09-22"><code>v3.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/compare/v3.0.1…v3.1.0">Compare Source</a></p>
<ul>
<li>Added: Support for [eslint-plugin-unicorn]. Thanks to John Mars (<a href="https://renovatebot.com/gh/j0hnm4r5">@&#8203;j0hnm4r5</a>)!</li>
<li>Changed: The [quotes] rule is now allowed to be used to forbid unnecessary<br />
backticks. This means that the CLI helper tool no longer can automatically<br />
validate it, so you’ll need to refer the [quotes special rule<br />
documentation][quotes-special]. Thanks to Nick Petruzzelli (<a href="https://renovatebot.com/gh/npetruzzelli">@&#8203;npetruzzelli</a>)!</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>